### PR TITLE
Enable multi-service SignalR connections

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -436,7 +436,7 @@
             height: 8px;
             border-radius: 50%;
             margin-right: 10px;
-            background-color: var(--green-primary);
+            background-color: var(--dot-color, var(--green-primary));
             position: relative;
             transition: color 0.3s ease;
         }
@@ -449,7 +449,7 @@
             width: 12px;
             height: 12px;
             border-radius: 50%;
-            background-color: var(--green-primary);
+            background-color: var(--dot-color, var(--green-primary));
             opacity: 0.3;
             animation: pulse-dot 2s infinite;
         }
@@ -751,7 +751,7 @@
         }
 
         .status-running span {
-            color: var(--green-primary);
+            color: var(--dot-color, var(--green-primary));
         }
 
         @keyframes statusPulse {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1276,6 +1276,7 @@
             flex-direction: column;
             gap: 8px;
             width: 100%; /* Ensure logs list takes full width */
+            min-height: 0; /* Allow scrolling within the container */
         }
 
         .log-entry {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1910,28 +1910,41 @@
         }
 
         .service-item.selected .service-name,
+        .service-item.active .service-name,
         .service-item.selected .service-status,
+        .service-item.active .service-status,
         .service-item.selected .service-actions,
+        .service-item.active .service-actions,
         .service-item.selected .service-actions i,
+        .service-item.active .service-actions i,
         .service-item.selected .service-actions i svg,
-        .service-item.selected .service-actions i svg path {
+        .service-item.active .service-actions i svg,
+        .service-item.selected .service-actions i svg path,
+        .service-item.active .service-actions i svg path {
             color: #ffffff !important;
             fill: #ffffff !important;
             stroke: #ffffff !important;
         }
 
         [data-theme="light"] .service-item.selected .service-name,
+        [data-theme="light"] .service-item.active .service-name,
         [data-theme="light"] .service-item.selected .service-status,
+        [data-theme="light"] .service-item.active .service-status,
         [data-theme="light"] .service-item.selected .service-actions,
+        [data-theme="light"] .service-item.active .service-actions,
         [data-theme="light"] .service-item.selected .service-actions i,
+        [data-theme="light"] .service-item.active .service-actions i,
         [data-theme="light"] .service-item.selected .service-actions i svg,
-        [data-theme="light"] .service-item.selected .service-actions i svg path {
+        [data-theme="light"] .service-item.active .service-actions i svg,
+        [data-theme="light"] .service-item.selected .service-actions i svg path,
+        [data-theme="light"] .service-item.active .service-actions i svg path {
             color: #ffffff !important;
             fill: #ffffff !important;
             stroke: #ffffff !important;
         }
 
-        .service-item.selected .service-actions i svg[style] {
+        .service-item.selected .service-actions i svg[style],
+        .service-item.active .service-actions i svg[style] {
             color: #ffffff !important;
             fill: none !important;
             stroke: #ffffff !important;
@@ -1940,7 +1953,8 @@
             stroke-linejoin: round !important;
         }
 
-        [data-theme="light"] .service-item.selected .service-actions i svg[style] {
+        [data-theme="light"] .service-item.selected .service-actions i svg[style],
+        [data-theme="light"] .service-item.active .service-actions i svg[style] {
             color: #ffffff !important;
             fill: none !important;
             stroke: #ffffff !important;

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -989,12 +989,15 @@
             border-color: rgba(148, 163, 184, 0.5);
         }
 
-        .logs-header {
-            display: flex;
-            align-items: center;
-            flex-direction: column;
-            gap: 20px; /* Space between controls and stats */
-        }
+.logs-header {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    gap: 20px; /* Space between controls and stats */
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+}
 
         .logs-controls-top {
             display: flex;
@@ -1457,6 +1460,9 @@
                 flex-direction: column;
                 align-items: stretch;
                 gap: 12px;
+                flex: 1;
+                min-height: 0;
+                overflow: auto;
             }
 
             .search-box {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -12,6 +12,7 @@
             --blue-glow: rgba(59, 130, 246, 0.3);
             --purple-primary: #8b5cf6;
             --green-primary: #10b981;
+            --gray-primary: #6b7280;
             --red-primary: #ef4444;
             --yellow-primary: #f59e0b;
             --card-radius: 12px;
@@ -217,6 +218,7 @@
             --blue-glow: rgba(59, 130, 246, 0.3);
             --purple-primary: #8b5cf6;
             --green-primary: #10b981;
+            --gray-primary: #9ca3af;
             --red-primary: #ef4444;
             --yellow-primary: #f59e0b;
             --card-radius: 12px;
@@ -399,6 +401,11 @@
             position: relative;
             overflow: hidden;
             height: 36px;
+            color: var(--text-secondary);
+        }
+
+        .service-item.connected {
+            color: var(--text-primary);
         }
 
         .service-item.active {
@@ -436,7 +443,7 @@
             height: 8px;
             border-radius: 50%;
             margin-right: 10px;
-            background-color: var(--dot-color, var(--green-primary));
+            background-color: var(--dot-color, var(--gray-primary));
             position: relative;
             transition: color 0.3s ease;
         }
@@ -449,7 +456,7 @@
             width: 12px;
             height: 12px;
             border-radius: 50%;
-            background-color: var(--dot-color, var(--green-primary));
+            background-color: var(--dot-color, var(--gray-primary));
             opacity: 0.3;
             animation: pulse-dot 2s infinite;
         }
@@ -751,7 +758,7 @@
         }
 
         .status-running span {
-            color: var(--dot-color, var(--green-primary));
+            color: var(--dot-color, var(--gray-primary));
         }
 
         @keyframes statusPulse {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,7 +34,7 @@
                 <i data-lucide="plus" class="expand-icon" onclick="addIconAnimation(this, 'plus-bounce')"></i>
             </div>
             <ul class="service-list" id="service-list">
-                <li class="service-item active" onclick="selectService(this, 0)">
+                <li class="service-item" onclick="selectService(this, 0)">
                     <div class="status-dot"></div>
                     <div class="service-name">File Manager Service</div>
                 </li>
@@ -95,7 +95,7 @@
                     </div>
                     <div class="metric-value status-running">
                         <div class="status-dot"></div>
-                        <span>Running</span>
+                        <span>--</span>
                     </div>
                 </div>
                 <div class="metric-card">
@@ -103,21 +103,21 @@
                         <i data-lucide="database" class="metric-icon"></i>
                         <div class="metric-label">Memory</div>
                     </div>
-                    <div class="metric-value" id="memory-value">35.4%</div>
+                    <div class="metric-value" id="memory-value">--</div>
                 </div>
                 <div class="metric-card">
                     <div class="metric-header">
                         <i data-lucide="cpu" class="metric-icon"></i>
                         <div class="metric-label">CPU</div>
                     </div>
-                    <div class="metric-value" id="cpu-value">20.5%</div>
+                    <div class="metric-value" id="cpu-value">--</div>
                 </div>
                 <div class="metric-card">
                     <div class="metric-header">
                         <i data-lucide="users" class="metric-icon"></i>
                         <div class="metric-label">Connections</div>
                     </div>
-                    <div class="metric-value" id="connections-value">77</div>
+                    <div class="metric-value" id="connections-value">--</div>
                 </div>
             </div>
 
@@ -178,10 +178,10 @@
                     </div>
 
                 <div class="logs-stats">
-                    <div class="log-stat total">Total: <strong>29</strong></div>
-                    <div class="log-stat info">Info: <strong>12</strong></div>
-                    <div class="log-stat warning">Warnings: <strong>8</strong></div>
-                    <div class="log-stat error">Errors: <strong>9</strong></div>
+                    <div class="log-stat total">Total: <strong>0</strong></div>
+                    <div class="log-stat info">Info: <strong>0</strong></div>
+                    <div class="log-stat warning">Warnings: <strong>0</strong></div>
+                    <div class="log-stat error">Errors: <strong>0</strong></div>
                 </div>
 
                 <div class="logs-list" id="logs-list">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -465,7 +465,7 @@ function connectToSignalR(serviceData) {
                 const logsList = document.getElementById("logs-list");
                 if (logsList && Array.isArray(data.applicationLogs)) {
                     const wasAtBottom =
-                        Math.abs(logsList.scrollHeight - logsList.clientHeight - logsList.scrollTop) <= 1;
+                        Math.abs(logsList.scrollHeight - logsList.clientHeight - logsList.scrollTop) <= 5;
                     data.applicationLogs.forEach((log) => {
                         const entry = parseLogEntry(log);
 

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -324,9 +324,8 @@ function connectToSignalR(serviceData) {
     // Reset status display when connecting if this service is active
     const statusElement = document.querySelector('.status-running');
     if (activeServiceId === serviceData.id && statusElement) {
-        const statusDot = statusElement.querySelector('.status-dot');
+        statusElement.style.setProperty('--dot-color', 'var(--yellow-primary)');
         const statusText = statusElement.querySelector('span');
-        statusDot.style.setProperty('--dot-color', 'var(--yellow-primary)');
         statusText.textContent = 'Connecting...';
     }
 
@@ -345,16 +344,9 @@ function connectToSignalR(serviceData) {
         // Update status in the metrics card only for the active service
         const statusElement = document.querySelector('.status-running');
         if (activeServiceId === serviceData.id && statusElement) {
-            const statusDot = statusElement.querySelector('.status-dot');
+            statusElement.style.setProperty('--dot-color', isRunning ? 'var(--green-primary)' : 'var(--red-primary)');
             const statusText = statusElement.querySelector('span');
-
-            if (isRunning) {
-                statusDot.style.setProperty('--dot-color', 'var(--green-primary)');
-                statusText.textContent = 'Running';
-            } else {
-                statusDot.style.setProperty('--dot-color', 'var(--red-primary)');
-                statusText.textContent = 'Stopped';
-            }
+            statusText.textContent = isRunning ? 'Running' : 'Stopped';
         }
 
         // Update the service dot in the sidebar
@@ -489,9 +481,8 @@ function selectService(element, index, service) {
     if (!serviceConnections[serviceData.id]) {
         const statusElement = document.querySelector('.status-running');
         if (statusElement) {
-            const statusDot = statusElement.querySelector('.status-dot');
+            statusElement.style.setProperty('--dot-color', 'var(--yellow-primary)');
             const statusText = statusElement.querySelector('span');
-            statusDot.style.setProperty('--dot-color', 'var(--yellow-primary)');
             statusText.textContent = 'Connecting...';
         }
     }
@@ -579,15 +570,9 @@ function renderServiceMetrics(serviceId) {
 
     const statusElement = document.querySelector('.status-running');
     if (statusElement) {
-        const statusDot = statusElement.querySelector('.status-dot');
+        statusElement.style.setProperty('--dot-color', metrics.serviceRunning ? 'var(--green-primary)' : 'var(--red-primary)');
         const statusText = statusElement.querySelector('span');
-        if (metrics.serviceRunning) {
-            statusDot.style.setProperty('--dot-color', 'var(--green-primary)');
-            statusText.textContent = 'Running';
-        } else {
-            statusDot.style.setProperty('--dot-color', 'var(--red-primary)');
-            statusText.textContent = 'Stopped';
-        }
+        statusText.textContent = metrics.serviceRunning ? 'Running' : 'Stopped';
     }
 }
 

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -56,6 +56,20 @@
     // Add event listener for service actions (ellipsis) using delegation
     container.addEventListener('click', handleServiceActionsClick);
 
+    // Auto-select the first service and attempt connections to all services
+    if (services.length > 0) {
+        const firstItem = container.querySelector('.service-item');
+        if (firstItem) {
+            selectService(firstItem, 0, services[0]);
+        }
+
+        services.forEach((srv, idx) => {
+            if (idx !== 0) {
+                connectToSignalR(srv);
+            }
+        });
+    }
+
   } catch (error) {
     console.error('Network error or exception while loading services:', error);
   }

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -464,6 +464,8 @@ function connectToSignalR(serviceData) {
 
                 const logsList = document.getElementById("logs-list");
                 if (logsList && Array.isArray(data.applicationLogs)) {
+                    const wasAtBottom =
+                        Math.abs(logsList.scrollHeight - logsList.clientHeight - logsList.scrollTop) <= 1;
                     data.applicationLogs.forEach((log) => {
                         const entry = parseLogEntry(log);
 
@@ -474,8 +476,11 @@ function connectToSignalR(serviceData) {
                             <div class="log-timestamp">${entry.timestamp}</div>
                             <div class="log-message">${entry.message}</div>
                         `;
-                        logsList.prepend(logDiv);
+                        logsList.appendChild(logDiv);
                     });
+                    if (wasAtBottom) {
+                        logsList.scrollTop = logsList.scrollHeight;
+                    }
                 }
 
                 updateLogStats();
@@ -606,7 +611,7 @@ function populateLogs(serviceId) {
     logsList.innerHTML = '';
     const logs = serviceLogs[serviceId] || [];
 
-    logs.slice().reverse().forEach((log) => {
+    logs.forEach((log) => {
         if (currentLogFilter !== 'all' && log.level !== currentLogFilter) {
             return;
         }
@@ -619,6 +624,8 @@ function populateLogs(serviceId) {
         `;
         logsList.appendChild(logEntry);
     });
+
+    logsList.scrollTop = logsList.scrollHeight;
 
     updateLogStats();
 }

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -336,6 +336,7 @@ function connectToSignalR(serviceData) {
         if (serviceDot) {
             serviceDot.style.setProperty('--dot-color', 'var(--yellow-primary)'); // Yellow color
         }
+        serviceItem.classList.add('connected');
     }
 
     function updateServiceStatus(isRunning) {
@@ -357,6 +358,7 @@ function connectToSignalR(serviceData) {
                 const color = isRunning ? 'var(--green-primary)' : 'var(--red-primary)';
                 serviceDot.style.setProperty('--dot-color', color);
             }
+            serviceItem.classList.add('connected');
         }
     }
 

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -285,7 +285,7 @@ function closeSidebar() {
 const outputToConsole = true; // set false to disable console logs
 
 // Add animation function
-function animateValue(element, start, end, duration, suffix = '') {
+function animateValue(element, start, end, duration, suffix = '', decimals = 1) {
     const startTime = performance.now();
     
     function updateValue(timestamp) {
@@ -296,13 +296,13 @@ function animateValue(element, start, end, duration, suffix = '') {
             : 1 - Math.pow(-2 * progress + 2, 2) / 2; // Ease in-out quad
         
         const value = start + (end - start) * easeProgress;
-        element.textContent = `${value.toFixed(1)}${suffix}`;
+        element.textContent = `${value.toFixed(decimals)}${suffix}`;
         
         if (progress < 1) {
             requestAnimationFrame(updateValue);
         } else {
-            // Always show one decimal place for the final value
-            element.textContent = `${Number(end).toFixed(1)}${suffix}`;
+            // Always show the specified number of decimal places for the final value
+            element.textContent = `${Number(end).toFixed(decimals)}${suffix}`;
         }
     }
     
@@ -422,9 +422,9 @@ function connectToSignalR(serviceData) {
                 const newMemory = parseMetricValue(data.memoryUsage, true);
                 const newConnections = parseMetricValue(data.activeConnections);
 
-                animateValue(cpuElement, currentCpu, newCpu, 1000, '%');
-                animateValue(memoryElement, currentMemory, newMemory, 1000, '%');
-                animateValue(connectionsElement, currentConnections, newConnections, 1000);
+                animateValue(cpuElement, currentCpu, newCpu, 1000, '%', 2);
+                animateValue(memoryElement, currentMemory, newMemory, 1000, '%', 2);
+                animateValue(connectionsElement, currentConnections, newConnections, 1000, '', 1);
 
                 const logsList = document.getElementById("logs-list");
                 if (logsList) {
@@ -580,8 +580,8 @@ function renderServiceMetrics(serviceId) {
     const memoryElement = document.getElementById('memory-value');
     const connectionsElement = document.getElementById('connections-value');
 
-    if (cpuElement) cpuElement.textContent = parseMetricValue(metrics.cpuUsage, true).toFixed(1) + '%';
-    if (memoryElement) memoryElement.textContent = parseMetricValue(metrics.memoryUsage, true).toFixed(1) + '%';
+    if (cpuElement) cpuElement.textContent = parseMetricValue(metrics.cpuUsage, true).toFixed(2) + '%';
+    if (memoryElement) memoryElement.textContent = parseMetricValue(metrics.memoryUsage, true).toFixed(2) + '%';
     if (connectionsElement) connectionsElement.textContent = parseMetricValue(metrics.activeConnections).toFixed(1);
 
     const statusElement = document.querySelector('.status-running');

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -328,7 +328,7 @@ function connectToSignalR(serviceData) {
     if (activeServiceId === serviceData.id && statusElement) {
         const statusDot = statusElement.querySelector('.status-dot');
         const statusText = statusElement.querySelector('span');
-        statusDot.style.backgroundColor = '#FFD700';
+        statusDot.style.setProperty('--dot-color', 'var(--yellow-primary)');
         statusText.textContent = 'Connecting...';
     }
 
@@ -337,7 +337,7 @@ function connectToSignalR(serviceData) {
     if (serviceItem) {
         const serviceDot = serviceItem.querySelector('.status-dot');
         if (serviceDot) {
-            serviceDot.style.backgroundColor = '#FFD700'; // Yellow color
+            serviceDot.style.setProperty('--dot-color', 'var(--yellow-primary)'); // Yellow color
         }
     }
 
@@ -351,10 +351,10 @@ function connectToSignalR(serviceData) {
             const statusText = statusElement.querySelector('span');
 
             if (isRunning) {
-                statusDot.style.backgroundColor = 'var(--green-primary)';
+                statusDot.style.setProperty('--dot-color', 'var(--green-primary)');
                 statusText.textContent = 'Running';
             } else {
-                statusDot.style.backgroundColor = 'var(--red-primary)';
+                statusDot.style.setProperty('--dot-color', 'var(--red-primary)');
                 statusText.textContent = 'Stopped';
             }
         }
@@ -364,7 +364,8 @@ function connectToSignalR(serviceData) {
         if (serviceItem) {
             const serviceDot = serviceItem.querySelector('.status-dot');
             if (serviceDot) {
-                serviceDot.style.backgroundColor = isRunning ? 'var(--green-primary)' : 'var(--red-primary)';
+                const color = isRunning ? 'var(--green-primary)' : 'var(--red-primary)';
+                serviceDot.style.setProperty('--dot-color', color);
             }
         }
     }
@@ -492,7 +493,7 @@ function selectService(element, index, service) {
         if (statusElement) {
             const statusDot = statusElement.querySelector('.status-dot');
             const statusText = statusElement.querySelector('span');
-            statusDot.style.backgroundColor = '#FFD700';
+            statusDot.style.setProperty('--dot-color', 'var(--yellow-primary)');
             statusText.textContent = 'Connecting...';
         }
     }
@@ -583,10 +584,10 @@ function renderServiceMetrics(serviceId) {
         const statusDot = statusElement.querySelector('.status-dot');
         const statusText = statusElement.querySelector('span');
         if (metrics.serviceRunning) {
-            statusDot.style.backgroundColor = 'var(--green-primary)';
+            statusDot.style.setProperty('--dot-color', 'var(--green-primary)');
             statusText.textContent = 'Running';
         } else {
-            statusDot.style.backgroundColor = 'var(--red-primary)';
+            statusDot.style.setProperty('--dot-color', 'var(--red-primary)');
             statusText.textContent = 'Stopped';
         }
     }

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -486,6 +486,17 @@ function selectService(element, index, service) {
     activeServiceId = serviceData.id;
     console.log('Selected service data:', serviceData);
 
+    // If this service has never been connected, show "Connecting..." feedback
+    if (!serviceConnections[serviceData.id]) {
+        const statusElement = document.querySelector('.status-running');
+        if (statusElement) {
+            const statusDot = statusElement.querySelector('.status-dot');
+            const statusText = statusElement.querySelector('span');
+            statusDot.style.backgroundColor = '#FFD700';
+            statusText.textContent = 'Connecting...';
+        }
+    }
+
     // Connect to SignalR for this service if not already connected
     if (!serviceConnections[serviceData.id]) {
         serviceConnections[serviceData.id] = connectToSignalR(serviceData);

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -669,16 +669,17 @@ function filterLogsByLevel(level) {
 }
 
 // Function to update log statistics
-function updateLogStats() {
-    const logs = document.querySelectorAll('.log-entry');
-    let info = 0, warning = 0, error = 0, total = 0;
+function updateLogStats(serviceId = activeServiceId) {
+    const logs = serviceLogs[serviceId] || [];
+    let info = 0, warning = 0, error = 0;
+
     logs.forEach(entry => {
-        if (entry.style.display === 'none') return;
-        total++;
-        if (entry.classList.contains('info')) info++;
-        else if (entry.classList.contains('warning')) warning++;
-        else if (entry.classList.contains('error')) error++;
+        if (entry.level === 'info') info++;
+        else if (entry.level === 'warning') warning++;
+        else if (entry.level === 'error') error++;
     });
+
+    const total = logs.length;
 
     const totalStat = document.querySelector('.log-stat.total strong');
     const infoStat = document.querySelector('.log-stat.info strong');

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -36,10 +36,8 @@
       };
       
       // Construct the inner HTML with status dot, service name, and actions (ellipsis)
-      const statusColor = 'var(--green-primary)'; // Placeholder
-      
       div.innerHTML = `
-          <div class="status-dot" style="background-color: ${statusColor};"></div>
+          <div class="status-dot"></div>
           <span class="service-name">${service.name}</span>
           <div class="service-actions" data-service-id="${service.id}"><i data-lucide="more-vertical"></i></div>
       `;


### PR DESCRIPTION
## Summary
- keep a connection per service in the dashboard frontend
- cache metrics and logs for each service
- show cached data when switching services

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483faad1a4833290097b936e46cb32