### PR TITLE
Add edit-only menu for Tomcat service

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,9 +50,12 @@
             <div class="sidebar-content">
                 <div class="sidebar-content-top" style="padding-bottom: 10px;">
                     <h4>Tomcat</h4>
-                    <div class="sidebar-content-top-item">
+                    <div class="sidebar-content-top-item" id="tomcat-sidebar-item">
                         <div class="status-dot"></div>
                         <span class="service-name" title="Tomcat Server">Tomcat Server</span>
+                        <div class="service-actions" data-service-type="tomcat" data-service-id="">
+                            <i data-lucide="more-vertical"></i>
+                        </div>
                     </div>
                 </div>
                 <div class="sidebar-content-bottom">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1516,15 +1516,27 @@ function setupLogSearch() {
 // Placeholder functions for context menu actions
 function handleEditService(serviceId) {
     console.log('Edit service with ID:', serviceId);
-    // Find the service data for the given ID
+    // Find the service data for the given ID among Windows services
     const serviceItems = document.querySelectorAll('.service-item');
     let serviceToEdit = null;
     serviceItems.forEach(item => {
         const serviceData = JSON.parse(item.dataset.service);
-        if (serviceData.id === serviceId) {
+        if (String(serviceData.id) === String(serviceId)) {
             serviceToEdit = serviceData;
         }
     });
+
+    // If not found, check the Tomcat service entry
+    if (!serviceToEdit) {
+        const tomcatItem = document.getElementById('tomcat-sidebar-item');
+        if (tomcatItem) {
+            const tomcatData = JSON.parse(tomcatItem.dataset.service);
+            const tomcatId = tomcatData.id === null ? '' : String(tomcatData.id);
+            if (serviceId === tomcatId || serviceId === 'null' || serviceId === '') {
+                serviceToEdit = tomcatData;
+            }
+        }
+    }
 
     if (serviceToEdit) {
         openEditServiceModal(serviceToEdit);


### PR DESCRIPTION
## Summary
- show context menu with only Edit on Tomcat service
- display placeholder Tomcat data when no Tomcat entry exists
- allow creating Tomcat service from Edit modal when no ID is set
- attach ellipsis menu to Tomcat entry

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6877d0714b708332aa66dbbce330d806