### PR TITLE
feat: show help tooltip on first visit

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -3938,6 +3938,31 @@ body {
     color: #06b6d4;   /* Teal icon color */
 }
 
+.tutorial-tooltip {
+    position: fixed;
+    background-color: #1f2937;
+    color: #fff;
+    padding: 8px 12px;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+    font-size: 14px;
+}
+
+.tutorial-tooltip button {
+    background: none;
+    border: none;
+    color: #fff;
+    margin-left: 8px;
+    cursor: pointer;
+    text-decoration: underline;
+    font-size: 12px;
+}
+
+.hidden {
+    display: none;
+}
+
 /* Light mode styles */
 [data-theme="light"] #tutorial-btn {
     background-color: rgba(6, 182, 212, 0.12) !important;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -965,7 +965,13 @@
         <div class="notification-content">
             <!-- Notification content will be populated by JavaScript -->
         </div>
-    </div>
+</div>
+</div>
+
+<!-- Tutorial tooltip shown on first visit -->
+<div id="tutorial-tooltip" class="tutorial-tooltip hidden">
+    If you want help any time you can press this icon for help.
+    <button id="tutorial-tooltip-close">Got it</button>
 </div>
 
 <!-- Lucide Icons CDN -->

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -2902,3 +2902,27 @@ function updateTomcatMetricsUI(metrics) {
 window.addEventListener('DOMContentLoaded', function() {
     setInterval(pollTomcatStatus, 5000);
 });
+
+// Show a tutorial tooltip on first visit
+document.addEventListener('DOMContentLoaded', () => {
+    if (localStorage.getItem('tutorialSeen')) return;
+
+    const btn = document.getElementById('tutorial-btn');
+    const tooltip = document.getElementById('tutorial-tooltip');
+
+    if (btn && tooltip) {
+        const rect = btn.getBoundingClientRect();
+        tooltip.style.top = `${rect.bottom + 8}px`;
+        tooltip.style.left = `${rect.left}px`;
+        tooltip.classList.remove('hidden');
+
+        const closeBtn = document.getElementById('tutorial-tooltip-close');
+        if (closeBtn) {
+            closeBtn.addEventListener('click', () => {
+                tooltip.classList.add('hidden');
+            });
+        }
+    }
+
+    localStorage.setItem('tutorialSeen', 'true');
+});


### PR DESCRIPTION
## Summary
- add first-visit tooltip explaining the help icon
- style tooltip and hide it after dismissal
- show tooltip only once using localStorage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6892272e3cc083329946f4721f901ced