### PR TITLE
Fetch Tomcat metrics when service selected

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -794,11 +794,13 @@ function selectService(element, index, service) {
 
     // Determine if this is a Tomcat service based on the service name
     const isTomcatService = serviceData.Name && serviceData.Name.toLowerCase().includes('tomcat');
-    
+
     if (isTomcatService) {
         // Show Tomcat panel for Tomcat services
         showTomcatPanel();
         activeServiceType = 'tomcat';
+        // Fetch Tomcat metrics immediately when selected
+        pollTomcatMetrics();
     } else {
         // Show Windows panel for Windows services
         showWindowsPanel();
@@ -1792,16 +1794,11 @@ function pushToBuffer(buffer, lines, maxSize = 200) {
 
 
 async function pollTomcatMetrics() {
+    // Only fetch Tomcat metrics when a Tomcat service is active
+    if (activeServiceType !== 'tomcat') return;
 
-
-    //const nowLabel = new Date().toLocaleTimeString().slice(0, 8);
+    // const nowLabel = new Date().toLocaleTimeString().slice(0, 8);
     const nowLabel = new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true });
-
-
-    const tomcatSidebarItem = document.getElementById('tomcat-service-list');
-    if (!tomcatSidebarItem) return;
-    const tomcatData = JSON.parse(tomcatSidebarItem.dataset.service);
-    if (!tomcatData || !tomcatData.id) return;
 
     try {
         const resp = await fetch('/api/service-control/tomcat/metrics');


### PR DESCRIPTION
## Summary
- Trigger Tomcat metrics polling immediately upon selecting a Tomcat service
- Poller now only fetches metrics when a Tomcat service is active, mirroring Windows service behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f7ba452c8332a6fd41cf5098cd6d