### PR TITLE
feat: show spinner while fetching metrics

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1327,7 +1327,32 @@ body {
     font-weight: 600;
     letter-spacing: -0.02em;
     position: relative;
-    display: inline-block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.fetching-indicator {
+    display: none;
+    align-items: center;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.fetching-indicator .spinner {
+    width: 12px;
+    height: 12px;
+    border: 2px solid var(--text-secondary);
+    border-top-color: transparent;
+    border-radius: 50%;
+    margin-right: 4px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .header-actions {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,18 +94,17 @@
         <div class="main-content">
             <div class="header">
                 <div class="header-left">
-                    <h1 class="page-title">Service Health Monitor
-                        <span id="fetching-indicator" class="fetching-indicator">
-                            <span class="spinner"></span>
-                            <span class="fetching-text">Fetching data...</span>
-                        </span>
-                    </h1>
+                    <h1 class="page-title">Service Health Monitor</h1>
                     <div class="user-info" id="user-info" style="display: none;">
                         <span class="user-name"></span>
                         <span class="user-room"></span>
                     </div>
                 </div>
                 <div class="header-actions">
+                    <span id="fetching-indicator" class="fetching-indicator">
+                        <span class="spinner"></span>
+                        <span class="fetching-text">Fetching data...</span>
+                    </span>
                     <div class="live-indicator">
                         <div class="live-dot"></div>
                         <span>Live</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,7 +94,12 @@
         <div class="main-content">
             <div class="header">
                 <div class="header-left">
-                    <h1 class="page-title">Service Health Monitor</h1>
+                    <h1 class="page-title">Service Health Monitor
+                        <span id="fetching-indicator" class="fetching-indicator">
+                            <span class="spinner"></span>
+                            <span class="fetching-text">Fetching data...</span>
+                        </span>
+                    </h1>
                     <div class="user-info" id="user-info" style="display: none;">
                         <span class="user-name"></span>
                         <span class="user-room"></span>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -319,6 +319,7 @@ async function updateServiceStatuses() {
         });
 
         updateStatusCard();
+        updateFetchingIndicator();
 
         const notifications = data.notifications || [];
         notifications.forEach(n => {
@@ -372,6 +373,8 @@ const serviceLogs = {};
 const serviceMetrics = {};
 const serviceStatuses = {};
 let windowsServices = [];
+let activeServiceType = 'windows';
+let tomcatMetricsAvailable = false;
 const MAX_LOGS = 200; // limit stored logs per service
 
 // Get modal elements and forms
@@ -849,6 +852,7 @@ function selectService(element, index, service) {
     renderServiceMetrics(serviceData.id);
 
     updateStatusCard();
+    updateFetchingIndicator();
 
 
 
@@ -934,7 +938,10 @@ function populateLogs(serviceId) {
 
 function renderServiceMetrics(serviceId) {
     const metrics = serviceMetrics[serviceId];
-    if (!metrics) return;
+    if (!metrics) {
+        updateFetchingIndicator();
+        return;
+    }
 
     const cpuElement = document.getElementById('cpu-value');
     const memoryElement = document.getElementById('memory-value');
@@ -946,6 +953,7 @@ function renderServiceMetrics(serviceId) {
 
     // Update the trend chart with stored history for this service
     updateResourceChartForService(serviceId);
+    updateFetchingIndicator();
 }
 
 function updateStatusCard() {
@@ -974,6 +982,20 @@ function updateStatusCard() {
             dot.style.setProperty('--dot-color', isRunning ? 'var(--green-primary)' : 'var(--red-primary)');
         }
     }
+}
+
+function updateFetchingIndicator() {
+    const indicator = document.getElementById('fetching-indicator');
+    if (!indicator || !activeServiceId) return;
+    const status = serviceStatuses[activeServiceId];
+    const isRunning = typeof status === 'string' && status.toLowerCase() === 'running';
+    let hasMetrics = false;
+    if (activeServiceType === 'tomcat') {
+        hasMetrics = tomcatMetricsAvailable;
+    } else {
+        hasMetrics = !!serviceMetrics[activeServiceId];
+    }
+    indicator.style.display = isRunning && !hasMetrics ? 'flex' : 'none';
 }
 
 // Function to toggle filter dropdown
@@ -1879,6 +1901,8 @@ async function pollTomcatMetrics() {
         if (!resp.ok) return;
         const metrics = await resp.json();
         updateTomcatMetricsUI(metrics);
+        tomcatMetricsAvailable = true;
+        if (activeServiceType === 'tomcat') updateFetchingIndicator();
 
         updateLiveChart(threadUsageChart, nowLabel, [
             metrics.threads?.max ?? null,
@@ -1901,6 +1925,8 @@ async function pollTomcatMetrics() {
         ]);
     } catch (err) {
         console.error('Error fetching Tomcat metrics:', err);
+        tomcatMetricsAvailable = false;
+        if (activeServiceType === 'tomcat') updateFetchingIndicator();
     }
 
     document.querySelectorAll('.tomcat-updated-time').forEach(el => {


### PR DESCRIPTION
## Summary
- show "Fetching data" spinner beside title when service metrics are unavailable
- track tomcat and windows metrics to toggle spinner once data arrives

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68af78b9e3948332a670dfa4e0136dc4